### PR TITLE
Fix container centering on small screens

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -62,7 +62,7 @@ footer {
   grid-row-start: -1;
   background: var(--light-green);
   color: var(--black);
-  width: 100vw;
+  width: 100%;
   margin-top: 2.5rem;
 }
 .section-header-container {

--- a/src/layouts/ToolBoxWrapper.vue
+++ b/src/layouts/ToolBoxWrapper.vue
@@ -93,7 +93,12 @@ export default {
   transform: translate3d(0, 0, 0);
   transition: transform 0.3s;
   background-color: var(--background-white);
-  justify-content: center;
+}
+/* Fix for unequal margin-left margin-right in ios */
+@media all and (max-width: 500px) {
+  #app > .container {
+    justify-content: center;
+  }
 }
 
 #app > .toolbox-open:nth-child(3) {


### PR DESCRIPTION
Revert the previous fixes on page container and page footer. Only set container Grid to be justified: center on small screens.